### PR TITLE
Plugin [1699,1700] - Http_enhancements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>HTTP Plugins</name>
   <groupId>io.cdap</groupId>
   <artifactId>http-plugins</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
 
   <licenses>
     <license>
@@ -437,6 +437,11 @@
       <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <version>9.4.12.v20180830</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -44,6 +44,9 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
     public static final String PROPERTY_CLIENT_SECRET = "clientSecret";
     public static final String PROPERTY_SCOPES = "scopes";
     public static final String PROPERTY_REFRESH_TOKEN = "refreshToken";
+    public static final String PROPERTY_PROXY_URL = "proxyUrl";
+    public static final String PROPERTY_PROXY_USERNAME = "proxyUsername";
+    public static final String PROPERTY_PROXY_PASSWORD = "proxyPassword";
 
     public static final String PROPERTY_AUTH_TYPE_LABEL = "Auth type";
 
@@ -86,6 +89,24 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
     @Description("Endpoint for the resource server, which exchanges the authorization code for an access token.")
     @Macro
     protected String tokenUrl;
+
+    @Nullable
+    @Name(PROPERTY_PROXY_URL)
+    @Description("Proxy URL. Must contain a protocol, address and port.")
+    @Macro
+    protected String proxyUrl;
+
+    @Nullable
+    @Name(PROPERTY_PROXY_USERNAME)
+    @Description("Proxy username.")
+    @Macro
+    protected String proxyUsername;
+
+    @Nullable
+    @Name(PROPERTY_PROXY_PASSWORD)
+    @Description("Proxy password.")
+    @Macro
+    protected String proxyPassword;
 
     @Nullable
     @Name(PROPERTY_CLIENT_ID)
@@ -255,6 +276,21 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         String serviceAccountType = getServiceAccountType();
         return Strings.isNullOrEmpty(serviceAccountType) ? null :
                 serviceAccountType.equals(PROPERTY_SERVICE_ACCOUNT_JSON);
+    }
+
+    @Nullable
+    public String getProxyUrl() {
+        return proxyUrl;
+    }
+
+    @Nullable
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    @Nullable
+    public String getProxyPassword() {
+        return proxyPassword;
     }
 
     @Nullable

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -27,14 +27,7 @@ import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.HttpProxy;
-import org.eclipse.jetty.client.ProxyConfiguration;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-
 import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -344,9 +337,7 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
 
     public void validate(FailureCollector failureCollector) {
         if (!containsMacro(PROPERTY_PROXY_URL) && !Strings.isNullOrEmpty(getProxyUrl())) {
-            SslContextFactory sslContextFactory = new SslContextFactory();
-            HttpClient httpClient = new HttpClient(sslContextFactory);
-            setProxy(httpClient);
+            setProxy();
         }
         // Validate OAuth2 properties
         if (!containsMacro(PROPERTY_OAUTH2_ENABLED) && this.getOauth2Enabled()) {
@@ -405,19 +396,9 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         }
     }
 
-    public void setProxy(HttpClient httpClient) {
+    public void setProxy() {
         if (!getProxyUrl().matches(REGEX_PROXY_URL)) {
             throw new IllegalArgumentException(String.format("Proxy URL format is wrong: %s.", getProxyUrl()));
-        }
-
-        try {
-            URI proxyUrl = new URI(getProxyUrl());
-            ProxyConfiguration proxyConfig = httpClient.getProxyConfiguration();
-            HttpProxy proxy = new HttpProxy(proxyUrl.getHost(), proxyUrl.getPort());
-            proxyConfig.getProxies().add(proxy);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(String.format("Cannot set up proxy server call with " +
-              "given proxy server details. Error : %s", e.getMessage()), e);
         }
     }
 

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -27,10 +27,10 @@ import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 
-import org.spark_project.jetty.client.HttpClient;
-import org.spark_project.jetty.client.HttpProxy;
-import org.spark_project.jetty.client.ProxyConfiguration;
-import org.spark_project.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.ProxyConfiguration;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.io.File;
 import java.net.URI;
@@ -76,7 +76,7 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
 
     public static final String PROPERTY_SERVICE_ACCOUNT_SCOPE = "serviceAccountScope";
 
-    public final String REGEX_PROXY_URL = "^(?i)(https?)://.*$";
+    public static final String REGEX_PROXY_URL = "^(?i)(https?)://.*$";
 
     @Name(PROPERTY_AUTH_TYPE)
     @Description("Type of authentication used to submit request. \n" +

--- a/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
@@ -167,10 +167,10 @@ public class HttpClient implements Closeable {
   /**
    * This class allows us to send body not only in POST/PUT but also in other requests.
    */
-  private static class HttpRequest extends HttpEntityEnclosingRequestBase {
+  public static class HttpRequest extends HttpEntityEnclosingRequestBase {
     private final String methodName;
 
-    HttpRequest(URI uri, String methodName) {
+    public HttpRequest(URI uri, String methodName) {
       super();
       this.setURI(uri);
       this.methodName = methodName;

--- a/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
@@ -105,7 +105,7 @@ public class OAuthUtil {
    * @return
    * @throws IOException
    */
-  private static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
+  public static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
                                                          BaseHttpConfig config) throws IOException {
     URI uri;
     try {

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -67,9 +67,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   public static final String PROPERTY_RESULT_PATH = "resultPath";
   public static final String PROPERTY_FIELDS_MAPPING = "fieldsMapping";
   public static final String PROPERTY_CSV_SKIP_FIRST_ROW = "csvSkipFirstRow";
-  public static final String PROPERTY_PROXY_URL = "proxyUrl";
-  public static final String PROPERTY_PROXY_USERNAME = "proxyUsername";
-  public static final String PROPERTY_PROXY_PASSWORD = "proxyPassword";
   public static final String PROPERTY_HTTP_ERROR_HANDLING = "httpErrorsHandling";
   public static final String PROPERTY_ERROR_HANDLING = "errorHandling";
   public static final String PROPERTY_RETRY_POLICY = "retryPolicy";
@@ -151,24 +148,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     "This is usually set if the first row is a header row.")
   @Macro
   protected String csvSkipFirstRow;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_URL)
-  @Description("Proxy URL. Must contain a protocol, address and port.")
-  @Macro
-  protected String proxyUrl;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_USERNAME)
-  @Description("Proxy username.")
-  @Macro
-  protected String proxyUsername;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_PASSWORD)
-  @Description("Proxy password.")
-  @Macro
-  protected String proxyPassword;
 
   @Nullable
   @Name(PROPERTY_HTTP_ERROR_HANDLING)
@@ -376,21 +355,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
 
   public Boolean getCsvSkipFirstRow() {
     return Boolean.parseBoolean(csvSkipFirstRow);
-  }
-
-  @Nullable
-  public String getProxyUrl() {
-    return proxyUrl;
-  }
-
-  @Nullable
-  public String getProxyUsername() {
-    return proxyUsername;
-  }
-
-  @Nullable
-  public String getProxyPassword() {
-    return proxyPassword;
   }
 
   @Nullable

--- a/widgets/HTTP-batchsink.json
+++ b/widgets/HTTP-batchsink.json
@@ -313,6 +313,26 @@
           }
         }
       ]
+    },
+    {
+      "label": "HTTP Proxy",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Proxy URL",
+          "name": "proxyUrl"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Username",
+          "name": "proxyUsername"
+        },
+        {
+          "widget-type": "password",
+          "label": "Password",
+          "name": "proxyPassword"
+        }
+      ]
     }
   ],
   "outputs": [],
@@ -340,6 +360,23 @@
             "name": "jsonBatchKey"
           }
         ]
+    },
+    {
+      "name": "Proxy authentication",
+      "condition": {
+        "property": "proxyUrl",
+        "operator": "exists"
+      },
+      "show": [
+        {
+          "name": "proxyUsername",
+          "type": "property"
+        },
+        {
+          "name": "proxyPassword",
+          "type": "property"
+        }
+      ]
     },
     {
       "name": "Authenticate with Basic Auth",


### PR DESCRIPTION
1. The HTTP Source Plugin offers different authentication methods but does not report errors for incorrect credentials provided in the authentication for a specific URL.
**Fix** 
Validate the credentials and provide meaningful errors to identify the field causing the failure for the supported Authentications.
Supported Auth: OAuth or basic auth (username and password)
https://cdap.atlassian.net/browse/PLUGIN-1699

2. Issue: HTTP Proxy Configuration Missing in HTTP Sink Plugin
**Fix **
To address this issue and provide users with HTTP Proxy support in the HTTP Sink plugin, we propose configuring the following fields:
HTTP Proxy : 
Proxy URL
Proxy Username 
Proxy Password 
https://cdap.atlassian.net/browse/PLUGIN-1700

