### PR TITLE
Plugin [1699,1700] - Http_enhancements with Code Integration for Retry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <jackson.version>2.9.9</jackson.version>
     <junit.version>4.11</junit.version>
     <jython.version>2.7.1</jython.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.24.0</mockito.version>
     <spark2.version>2.1.3</spark2.version>
     <unxml.version>0.9</unxml.version>
     <wiremock.version>1.49</wiremock.version>
@@ -428,8 +428,20 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>HTTP Plugins</name>
   <groupId>io.cdap</groupId>
   <artifactId>http-plugins</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.2-SNAPSHOT</version>
 
   <licenses>
     <license>
@@ -437,6 +437,11 @@
       <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <version>9.4.12.v20180830</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -44,6 +44,9 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
     public static final String PROPERTY_CLIENT_SECRET = "clientSecret";
     public static final String PROPERTY_SCOPES = "scopes";
     public static final String PROPERTY_REFRESH_TOKEN = "refreshToken";
+    public static final String PROPERTY_PROXY_URL = "proxyUrl";
+    public static final String PROPERTY_PROXY_USERNAME = "proxyUsername";
+    public static final String PROPERTY_PROXY_PASSWORD = "proxyPassword";
 
     public static final String PROPERTY_AUTH_TYPE_LABEL = "Auth type";
 
@@ -86,6 +89,24 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
     @Description("Endpoint for the resource server, which exchanges the authorization code for an access token.")
     @Macro
     protected String tokenUrl;
+
+    @Nullable
+    @Name(PROPERTY_PROXY_URL)
+    @Description("Proxy URL. Must contain a protocol, address and port.")
+    @Macro
+    protected String proxyUrl;
+
+    @Nullable
+    @Name(PROPERTY_PROXY_USERNAME)
+    @Description("Proxy username.")
+    @Macro
+    protected String proxyUsername;
+
+    @Nullable
+    @Name(PROPERTY_PROXY_PASSWORD)
+    @Description("Proxy password.")
+    @Macro
+    protected String proxyPassword;
 
     @Nullable
     @Name(PROPERTY_CLIENT_ID)
@@ -255,6 +276,21 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         String serviceAccountType = getServiceAccountType();
         return Strings.isNullOrEmpty(serviceAccountType) ? null :
                 serviceAccountType.equals(PROPERTY_SERVICE_ACCOUNT_JSON);
+    }
+
+    @Nullable
+    public String getProxyUrl() {
+        return proxyUrl;
+    }
+
+    @Nullable
+    public String getProxyUsername() {
+        return proxyUsername;
+    }
+
+    @Nullable
+    public String getProxyPassword() {
+        return proxyPassword;
     }
 
     @Nullable

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -27,14 +27,7 @@ import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 
-import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.HttpProxy;
-import org.eclipse.jetty.client.ProxyConfiguration;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
-
 import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -344,9 +337,7 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
 
     public void validate(FailureCollector failureCollector) {
         if (!containsMacro(PROPERTY_PROXY_URL) && !Strings.isNullOrEmpty(getProxyUrl())) {
-            SslContextFactory sslContextFactory = new SslContextFactory();
-            HttpClient httpClient = new HttpClient(sslContextFactory);
-            setProxy(httpClient);
+            setProxy();
         }
         // Validate OAuth2 properties
         if (!containsMacro(PROPERTY_OAUTH2_ENABLED) && this.getOauth2Enabled()) {
@@ -405,19 +396,9 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         }
     }
 
-    public void setProxy(HttpClient httpClient) {
+    public void setProxy() {
         if (!getProxyUrl().matches(REGEX_PROXY_URL)) {
             throw new IllegalArgumentException(String.format("Proxy URL format is wrong: %s.", getProxyUrl()));
-        }
-
-        try {
-            URI proxyUrl = new URI(getProxyUrl());
-            ProxyConfiguration proxyConfig = httpClient.getProxyConfiguration();
-            HttpProxy proxy = new HttpProxy(proxyUrl.getHost(), proxyUrl.getPort());
-            proxyConfig.getProxies().add(proxy);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException(String.format("Cannot set up proxy server call with " +
-              "given proxy server details. Error : %s", e.getMessage()), e);
         }
     }
 

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -342,7 +342,6 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         // Validate OAuth2 properties
         if (!containsMacro(PROPERTY_OAUTH2_ENABLED) && this.getOauth2Enabled()) {
             String reasonOauth2 = "OAuth2 is enabled";
-            assertIsSet(getAuthUrl(), PROPERTY_AUTH_URL, reasonOauth2);
             assertIsSet(getTokenUrl(), PROPERTY_TOKEN_URL, reasonOauth2);
             assertIsSet(getClientId(), PROPERTY_CLIENT_ID, reasonOauth2);
             assertIsSet(getClientSecret(), PROPERTY_CLIENT_SECRET, reasonOauth2);
@@ -354,9 +353,6 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         switch (authType) {
             case OAUTH2:
                 String reasonOauth2 = "OAuth2 is enabled";
-                if (!containsMacro(PROPERTY_AUTH_URL)) {
-                    assertIsSet(getAuthUrl(), PROPERTY_AUTH_URL, reasonOauth2);
-                }
                 if (!containsMacro(PROPERTY_TOKEN_URL)) {
                     assertIsSet(getTokenUrl(), PROPERTY_TOKEN_URL, reasonOauth2);
                 }

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -27,10 +27,10 @@ import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 
-import org.spark_project.jetty.client.HttpClient;
-import org.spark_project.jetty.client.HttpProxy;
-import org.spark_project.jetty.client.ProxyConfiguration;
-import org.spark_project.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.ProxyConfiguration;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.io.File;
 import java.net.URI;
@@ -76,7 +76,7 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
 
     public static final String PROPERTY_SERVICE_ACCOUNT_SCOPE = "serviceAccountScope";
 
-    public final String REGEX_PROXY_URL = "^(?i)(https?)://.*$";
+    public static final String REGEX_PROXY_URL = "^(?i)(https?)://.*$";
 
     @Name(PROPERTY_AUTH_TYPE)
     @Description("Type of authentication used to submit request. \n" +

--- a/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
@@ -167,10 +167,10 @@ public class HttpClient implements Closeable {
   /**
    * This class allows us to send body not only in POST/PUT but also in other requests.
    */
-  private static class HttpRequest extends HttpEntityEnclosingRequestBase {
+  public static class HttpRequest extends HttpEntityEnclosingRequestBase {
     private final String methodName;
 
-    HttpRequest(URI uri, String methodName) {
+    public HttpRequest(URI uri, String methodName) {
       super();
       this.setURI(uri);
       this.methodName = methodName;

--- a/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
@@ -105,7 +105,7 @@ public class OAuthUtil {
    * @return
    * @throws IOException
    */
-  private static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
+  public static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
                                                          BaseHttpConfig config) throws IOException {
     URI uri;
     try {

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
@@ -26,9 +26,20 @@ import io.cdap.plugin.http.common.error.HttpErrorHandler;
 import io.cdap.plugin.http.common.error.RetryableErrorHandling;
 import io.cdap.plugin.http.common.http.HttpClient;
 import io.cdap.plugin.http.common.http.OAuthUtil;
+
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
 import org.awaitility.Awaitility;
 import org.awaitility.Duration;
@@ -39,9 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URI;
@@ -56,6 +65,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -152,8 +162,9 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
   }
 
   private boolean executeHTTPServiceAndCheckStatusCode() throws IOException {
-    HttpURLConnection conn = null;
+    CloseableHttpClient httpClient = HttpClients.createDefault();
 
+    CloseableHttpResponse response = null;
     Map<String, String> headers = config.getRequestHeadersMap();
 
     if (accessToken == null || OAuthUtil.tokenExpired(accessToken)) {
@@ -162,48 +173,77 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
 
     if (accessToken != null) {
       Header authorizationHeader = new BasicHeader("Authorization",
-                                                   String.format("Bearer %s", accessToken.getTokenValue()));
+        String.format("Bearer %s", accessToken.getTokenValue()));
       headers.putAll(config.getHeadersMap(String.valueOf(authorizationHeader)));
     }
 
+    headers.put("Request-Method", config.getMethod().toUpperCase());
+    headers.put("Connect-Timeout", String.valueOf(config.getConnectTimeout()));
+    headers.put("Read-Timeout", String.valueOf(config.getReadTimeout()));
+    headers.put("Instance-Follow-Redirects", String.valueOf(config.getFollowRedirects()));
+    headers.put("charset", config.getCharset());
+
     try {
-      URL url = new URL(configURL);
-      conn = (HttpURLConnection) url.openConnection();
-      if (conn instanceof HttpsURLConnection) {
-        //Disable SSLv3
+      URL url = new URL(config.getUrl());
+      HttpEntityEnclosingRequestBase request = new HttpClient.HttpRequest(URI.create(String.valueOf(url)),
+        config.getMethod());
+
+      if (!Strings.isNullOrEmpty(config.getProxyUrl())) {
+        URL proxyURL = new URL(config.getProxyUrl());
+        String proxyHost = proxyURL.getHost();
+        int proxyPort = proxyURL.getPort();
+        String proxyUser = config.getProxyUsername();
+        String proxyPassword = config.getProxyPassword();
+
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(
+          new AuthScope(proxyHost, proxyPort),
+          new UsernamePasswordCredentials(proxyUser, proxyPassword));
+
+        HttpHost proxy = new HttpHost(proxyHost, proxyPort);
+        httpClient = HttpClients.custom()
+          .setDefaultCredentialsProvider(credsProvider)
+          .setProxy(proxy)
+          .build();
+      }
+
+      if (url.getProtocol().equalsIgnoreCase("https")) {
+        // Disable SSLv3
         System.setProperty("https.protocols", "TLSv1,TLSv1.1,TLSv1.2");
         if (config.getDisableSSLValidation()) {
           disableSSLValidation();
         }
       }
-      conn.setRequestMethod(config.getMethod().toUpperCase());
-      conn.setConnectTimeout(config.getConnectTimeout());
-      conn.setReadTimeout(config.getReadTimeout());
-      conn.setInstanceFollowRedirects(config.getFollowRedirects());
-      conn.addRequestProperty("charset", config.getCharset());
-      for (Map.Entry<String, String> propertyEntry : headers.entrySet()) {
-        conn.addRequestProperty(propertyEntry.getKey(), propertyEntry.getValue());
-      }
-      //Default contentType value would be added in the request properties if user has not added in the headers.
+
       if (config.getMethod().equals("POST") || config.getMethod().equals("PUT")) {
         if (!headers.containsKey("Content-Type")) {
-          conn.addRequestProperty("Content-Type", contentType);
+          headers.put("Content-Type", contentType);
         }
       }
+
       if (!messageBuffer.isEmpty()) {
-        conn.setDoOutput(true);
-        try (OutputStream outputStream = conn.getOutputStream()) {
-          outputStream.write(messageBuffer.getMessage().trim().getBytes(config.getCharset()));
+        String requestBodyString = messageBuffer.getMessage();
+        if (requestBodyString != null) {
+          StringEntity requestBody = new StringEntity(requestBodyString, Charsets.UTF_8.toString());
+          request.setEntity(requestBody);
         }
       }
-      httpStatusCode = conn.getResponseCode();
+
+      for (Map.Entry<String, String> propertyEntry : headers.entrySet()) {
+        request.addHeader(propertyEntry.getKey(), propertyEntry.getValue());
+      }
+
+      response = httpClient.execute(request);
+
+      httpStatusCode = response.getStatusLine().getStatusCode();
+
     } catch (MalformedURLException | ProtocolException e) {
       throw new IllegalStateException("Error opening url connection. Reason: " + e.getMessage(), e);
     } catch (IOException e) {
       LOG.warn("Error making {} request to url {} with headers {}.", config.getMethod(), config.getUrl(), headers);
     } finally {
-      if (conn != null) {
-        conn.disconnect();
+      if (response != null) {
+        response.close();
       }
     }
     RetryableErrorHandling errorHandlingStrategy = httpErrorHandler.getErrorHandlingStrategy(httpStatusCode);

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
@@ -17,11 +17,14 @@
 package io.cdap.plugin.http.sink.batch;
 
 import com.google.auth.oauth2.AccessToken;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.http.common.RetryPolicy;
 import io.cdap.plugin.http.common.error.HttpErrorHandler;
 import io.cdap.plugin.http.common.error.RetryableErrorHandling;
+import io.cdap.plugin.http.common.http.HttpClient;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -41,6 +44,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.security.KeyManagementException;
@@ -102,7 +106,7 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
     if (config.getMethod().equals("POST") || config.getMethod().equals("PUT")) {
       messageBuffer.add(input);
     }
-    
+
     if (config.getMethod().equals("PUT") || config.getMethod().equals("DELETE") && !placeHolderList.isEmpty()) {
       configURL = updateURLWithPlaceholderValue(input);
     }
@@ -262,5 +266,5 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
     }
     messageBuffer.clear();
   }
-  
+
 }

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
@@ -184,7 +184,7 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
     headers.put("charset", config.getCharset());
 
     try {
-      URL url = new URL(config.getUrl());
+      URL url = new URL(configURL);
       HttpEntityEnclosingRequestBase request = new HttpClient.HttpRequest(URI.create(String.valueOf(url)),
         config.getMethod());
 

--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
@@ -17,6 +17,7 @@ package io.cdap.plugin.http.source.batch;
 
 import com.google.auth.oauth2.AccessToken;
 import com.google.common.base.Strings;
+import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.HttpClient;
@@ -92,6 +93,8 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
           collector.addFailure("Unable to validate the proxy", null);
         }
       }
+    } catch (JsonSyntaxException e) {
+      throw new IllegalStateException("Error executing the request using this token URL: ", e);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
@@ -24,20 +24,20 @@ import io.cdap.plugin.http.common.http.HttpClient;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
 
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
-import java.net.URL;
 
 /**
  * Provides all the configurations required for configuring the {@link HttpBatchSource} plugin.
@@ -66,48 +66,41 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
   }
 
   private void validateOAuth2Credentials(FailureCollector collector) throws IOException {
-    try (CloseableHttpClient client = HttpClients.createDefault()) {
-      AccessToken accessToken = OAuthUtil.getAccessTokenByRefreshToken(client, this);
+    try {
+      HttpClientBuilder httpclientBuilder = HttpClients.custom();
       if (!containsMacro(PROPERTY_PROXY_URL) && !Strings.isNullOrEmpty(getProxyUrl())) {
-        URL proxyURL = new URL(proxyUrl);
-
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        credsProvider.setCredentials(
-          new AuthScope(proxyURL.getHost(), proxyURL.getPort()),
-          new UsernamePasswordCredentials(proxyUsername, proxyPassword));
-
-        HttpHost proxy = new HttpHost(proxyUrl, proxyURL.getPort());
-        CloseableHttpClient httpclient = HttpClients.custom()
-          .setDefaultCredentialsProvider(credsProvider)
-          .setProxy(proxy)
-          .build();
-
-        // Validating main URL with OAuth2
-        HttpGet request = new HttpGet(url);
-        request.addHeader("Authorization", "Bearer " + accessToken);
-        HttpResponse response = httpclient.execute(request);
-
-        // Validate the response
-        int statusCode = response.getStatusLine().getStatusCode();
-        if (statusCode != 200) {
-          collector.addFailure("Unable to validate the proxy", null);
+        HttpHost proxyHost = HttpHost.create(getProxyUrl());
+        if (!Strings.isNullOrEmpty(getProxyUsername()) && !Strings.isNullOrEmpty(getProxyPassword())
+          && !containsMacro(PROPERTY_PROXY_USERNAME) && !containsMacro(PROPERTY_PROXY_PASSWORD)) {
+          CredentialsProvider credsProvider = new BasicCredentialsProvider();
+          credsProvider.setCredentials(new AuthScope(proxyHost),
+            new UsernamePasswordCredentials(getProxyUsername(), getProxyPassword()));
+          httpclientBuilder.setDefaultCredentialsProvider(credsProvider);
         }
+        httpclientBuilder.setProxy(proxyHost);
       }
-    } catch (JsonSyntaxException e) {
-      throw new IllegalStateException("Error executing the request using this token URL: ", e);
+      CloseableHttpClient closeableHttpClient = httpclientBuilder.build();
+      AccessToken accessToken = OAuthUtil.getAccessTokenByRefreshToken(closeableHttpClient, this);
+    } catch (JsonSyntaxException | HttpHostConnectException e) {
+      throw new IllegalStateException("Error executing this request: " + e.getMessage(), e);
     }
   }
 
-  private void validateBasicAuthCredentials(FailureCollector collector) throws IOException {
+  public void validateBasicAuthCredentials(FailureCollector collector) throws IOException {
     try {
       HttpClient httpClient = new HttpClient(this);
       CloseableHttpResponse response = httpClient.executeHTTP(getUrl());
-      if (response.getStatusLine().getStatusCode() != 200) {
-        collector.addFailure("Error encountered while configuring the stage: 'Unable to authenticate the given " +
-          "username and password'", "Please check the basic and proxy authentication");
+      int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode != 200) {
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+          String errorResponse = EntityUtils.toString(entity, "UTF-8");
+          String errorMessage = String.format("Request failed with status code: %d %s", statusCode, errorResponse);
+          collector.addFailure(errorMessage, null);
+        }
       }
     } catch (HttpHostConnectException e) {
-      throw new IllegalStateException("Error executing HTTP request using this proxy URL: " + e.getMessage(), e);
+      throw new IllegalStateException("Error executing HTTP request: " + e.getMessage(), e);
     }
   }
 
@@ -126,6 +119,16 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     this.paginationType = builder.paginationType;
     this.verifyHttps = builder.verifyHttps;
     this.authType = builder.authType;
+    this.authUrl = builder.authUrl;
+    this.clientId = builder.clientId;
+    this.clientSecret = builder.clientSecret;
+    this.username = builder.username;
+    this.password = builder.password;
+    this.tokenUrl = builder.tokenUrl;
+    this.refreshToken = builder.refreshToken;
+    this.proxyUrl = builder.proxyUrl;
+    this.proxyUsername = builder.proxyUsername;
+    this.proxyPassword = builder.proxyPassword;
   }
 
   public static HttpBatchSourceConfigBuilder builder() {
@@ -151,9 +154,75 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     private String paginationType;
     private String verifyHttps;
     private String authType;
+    public String authUrl;
+    public String tokenUrl;
+    public String clientId;
+    public String clientSecret;
+    public String scopes;
+    public String refreshToken;
+    public String proxyUrl;
+    public String proxyUsername;
+    public String proxyPassword;
+    public String username;
+    public String password;
+
 
     public HttpBatchSourceConfigBuilder setReferenceName (String referenceName) {
       this.referenceName = referenceName;
+      return this;
+    }
+    public HttpBatchSourceConfigBuilder setAuthUrl(String authUrl) {
+      this.authUrl = authUrl;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setTokenUrl(String tokenUrl) {
+      this.tokenUrl = tokenUrl;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setClientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setScopes(String scopes) {
+      this.scopes = scopes;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setRefreshToken(String refreshToken) {
+      this.refreshToken = refreshToken;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setProxyUrl(String proxyUrl) {
+      this.proxyUrl = proxyUrl;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setProxyUsername(String proxyUsername) {
+      this.proxyUsername = proxyUsername;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setProxyPassword(String proxyPassword) {
+      this.proxyPassword = proxyPassword;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setUsername(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setPassword(String password) {
+      this.password = password;
       return this;
     }
 

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -67,9 +67,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   public static final String PROPERTY_RESULT_PATH = "resultPath";
   public static final String PROPERTY_FIELDS_MAPPING = "fieldsMapping";
   public static final String PROPERTY_CSV_SKIP_FIRST_ROW = "csvSkipFirstRow";
-  public static final String PROPERTY_PROXY_URL = "proxyUrl";
-  public static final String PROPERTY_PROXY_USERNAME = "proxyUsername";
-  public static final String PROPERTY_PROXY_PASSWORD = "proxyPassword";
   public static final String PROPERTY_HTTP_ERROR_HANDLING = "httpErrorsHandling";
   public static final String PROPERTY_ERROR_HANDLING = "errorHandling";
   public static final String PROPERTY_RETRY_POLICY = "retryPolicy";
@@ -151,24 +148,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     "This is usually set if the first row is a header row.")
   @Macro
   protected String csvSkipFirstRow;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_URL)
-  @Description("Proxy URL. Must contain a protocol, address and port.")
-  @Macro
-  protected String proxyUrl;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_USERNAME)
-  @Description("Proxy username.")
-  @Macro
-  protected String proxyUsername;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_PASSWORD)
-  @Description("Proxy password.")
-  @Macro
-  protected String proxyPassword;
 
   @Nullable
   @Name(PROPERTY_HTTP_ERROR_HANDLING)
@@ -376,21 +355,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
 
   public Boolean getCsvSkipFirstRow() {
     return Boolean.parseBoolean(csvSkipFirstRow);
-  }
-
-  @Nullable
-  public String getProxyUrl() {
-    return proxyUrl;
-  }
-
-  @Nullable
-  public String getProxyUsername() {
-    return proxyUsername;
-  }
-
-  @Nullable
-  public String getProxyPassword() {
-    return proxyPassword;
   }
 
   @Nullable

--- a/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
@@ -16,36 +16,163 @@
 
 package io.cdap.plugin.http.source.common;
 
+import com.google.auth.oauth2.AccessToken;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.http.common.http.HttpClient;
+import io.cdap.plugin.http.common.http.OAuthUtil;
+import io.cdap.plugin.http.common.pagination.BaseHttpPaginationIterator;
+import io.cdap.plugin.http.common.pagination.PaginationIteratorFactory;
 import io.cdap.plugin.http.source.batch.HttpBatchSourceConfig;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
 
 /**
  * Unit tests for HttpBatchSourceConfig
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PaginationIteratorFactory.class, HttpClientBuilder.class, HttpClients.class, OAuthUtil.class,
+  HttpHost.class, EntityUtils.class, HttpClient.class})
+@PowerMockIgnore("javax.management.*")
 public class HttpBatchSourceConfigTest {
 
-    @Test (expected = IllegalArgumentException.class)
-    public void testMissingKeyValue() {
-        FailureCollector collector = new MockFailureCollector();
-        HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
-                .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:")
-                .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-                .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-                .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
-        config.validate(collector);
-    }
+  @Test(expected = IllegalArgumentException.class)
+  public void testMissingKeyValue() {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+    config.validate(collector);
+  }
 
-    @Test (expected = InvalidConfigPropertyException.class)
-    public void testEmptySchemaKeyValue() {
-        HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
-                .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
-                .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-                .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-                .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
-        config.validateSchema();
+  @Test(expected = InvalidConfigPropertyException.class)
+  public void testEmptySchemaKeyValue() {
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+    config.validateSchema();
+  }
+
+  @Test
+  public void testValidateOAuth2() throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").build();
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any())).thenReturn(accessToken);
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+
+  @Test
+  public void testValidateOAuth2CredentialsWithProxy() throws IOException {
+    FailureCollector collectorMock = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").setProxyUrl("https://proxy").setProxyUsername("proxyuser").setProxyPassword("proxypassword")
+      .build();
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    HttpHost proxy = PowerMockito.mock(HttpHost.class);
+    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+    httpClientBuilder.setProxy(proxy);
+    PowerMockito.mockStatic(HttpClients.class);
+    CloseableHttpClient closeableHttpClient = Mockito.mock(CloseableHttpClient.class);
+    Mockito.when(HttpClients.createDefault()).thenReturn(closeableHttpClient);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(HttpClients.custom()
+      .setDefaultCredentialsProvider(credentialsProvider)
+      .setProxy(proxy)
+      .build()).thenReturn(closeableHttpClient);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any())).thenReturn(accessToken);
+    config.validate(collectorMock);
+  }
+
+  @Test
+  public void testValidateCredentialsOAuth2WithInvalidAccessTokenRequest() throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").build();
+    CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
+    HttpEntity entity = Mockito.mock(HttpEntity.class);
+    Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+    PowerMockito.mockStatic(EntityUtils.class);
+    String response = "  <title>Error 404 (Not Found)!!1</title>\n" +
+      "  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n" +
+      "  <p><b>404.</b> <ins>That’s an error.</ins>\n";
+
+    Mockito.when(EntityUtils.toString(entity, "UTF-8")).thenReturn(response);
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(httpClientBuilder.build()).thenReturn(httpClientMock);
+    try {
+      config.validate(collector);
+      Assert.fail("Exception will not be thrown with valid credentials");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals("Error executing this request: com.google.gson.stream.MalformedJsonException: " +
+        "Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 17 path $", e.getMessage());
     }
+  }
 }
+
+

--- a/widgets/HTTP-batchsink.json
+++ b/widgets/HTTP-batchsink.json
@@ -359,6 +359,26 @@
           }
         }
       ]
+    },
+    {
+      "label": "HTTP Proxy",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Proxy URL",
+          "name": "proxyUrl"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Username",
+          "name": "proxyUsername"
+        },
+        {
+          "widget-type": "password",
+          "label": "Password",
+          "name": "proxyPassword"
+        }
+      ]
     }
   ],
   "outputs": [],
@@ -398,6 +418,23 @@
         {
           "type": "property",
           "name": "jsonBatchKey"
+        }
+      ]
+    },
+    {
+      "name": "Proxy authentication",
+      "condition": {
+        "property": "proxyUrl",
+        "operator": "exists"
+      },
+      "show": [
+        {
+          "name": "proxyUsername",
+          "type": "property"
+        },
+        {
+          "name": "proxyPassword",
+          "type": "property"
         }
       ]
     },


### PR DESCRIPTION
Code Integration with **https://github.com/data-integrations/http/pull/144**

The HTTP Source Plugin offers different authentication methods but does not report errors for incorrect credentials provided in the authentication for a specific URL.
Fix
Validate the credentials and provide meaningful errors to identify the field causing the failure for the supported Authentications.
Supported Auth: OAuth or basic auth (username and password)
https://cdap.atlassian.net/browse/PLUGIN-1699

Issue: HTTP Proxy Configuration Missing in HTTP Sink Plugin
**Fix **
To address this issue and provide users with HTTP Proxy support in the HTTP Sink plugin, we propose configuring the following fields:
HTTP Proxy :
Proxy URL
Proxy Username
Proxy Password
https://cdap.atlassian.net/browse/PLUGIN-1700